### PR TITLE
Fixing github.com/satori/go.uuid as it contained a breaking update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/prometheus/client_golang v1.5.1 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
 	github.com/rs/cors v0.0.0-20181011182759-a3460e445dd3 // indirect
-	github.com/satori/go.uuid v1.2.0
+	github.com/satori/go.uuid v1.1.0
 	github.com/spf13/pflag v1.0.3 // indirect
 	github.com/ugorji/go v0.0.0-20170107133203-ded73eae5db7 // indirect
 	github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -329,8 +329,8 @@ github.com/rs/cors v0.0.0-20181011182759-a3460e445dd3/go.mod h1:gFx+x8UowdsKA9Ac
 github.com/rs/xhandler v0.0.0-20160618193221-ed27b6fd6521/go.mod h1:RvLn4FgxWubrpZHtQLnOf6EwhN2hEMusxZOhcW9H3UQ=
 github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/satori/go.uuid v1.2.0 h1:0uYX9dsZ2yD7q2RtLRtPSdGDWzjeM3TbMJP9utgA0ww=
-github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/satori/go.uuid v1.1.0 h1:B9KXyj+GzIpJbV7gmr873NsY6zpbxNy24CBtGrk7jHo=
+github.com/satori/go.uuid v1.1.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shirou/gopsutil v2.20.5+incompatible h1:tYH07UPoQt0OCQdgWWMgYHy3/a9bcxNpBIysykNIP7I=
 github.com/shirou/gopsutil v2.20.5+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=


### PR DESCRIPTION
github.com/satori/go.uuid v1.2.0 contained a breaking change due to which `go get github.com/Consensys/istanbul-tools/cmd/istanbul` fails with error 
```
go get github.com/Consensys/istanbul-tools/cmd/istanbul
# github.com/jpmorganchase/istanbul-tools/common
../../jpmorganchase/istanbul-tools/common/utils.go:57:97: multiple-value uuid.NewV4() in single-value context
```
Reverting back to previous version to fix the issue